### PR TITLE
Remove Bluefin branding and replace with Bluekitten branding

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -38,14 +38,10 @@ dnf -y --enablerepo "tailscale-stable" install \
 
 dnf -y copr enable ublue-os/packages
 dnf -y copr disable ublue-os/packages
-dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages swap \
-	almalinux-logos bluefin-logos
+
 
 # Bluefin Branding and tools
 dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
-	-x bluefin-logos \
-	-x bluefin-readymade-config \
-	-x bluefin-plymouth \
 	ublue-os-just \
 	ublue-os-luks \
 	ublue-os-signing \
@@ -53,7 +49,6 @@ dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
 	ublue-os-update-services \
 	ublue-{motd,fastfetch,bling,rebase-helper,setup-services,polkit-rules,brew} \
 	uupd \
-	bluefin-*
 
 # Upstream ublue-os-signing bug, we are using /usr/etc for the container signing and bootc gets mad at this
 # FIXME: remove this once https://github.com/ublue-os/packages/issues/245 is closed
@@ -90,7 +85,7 @@ dnf -y remove gnome-shell-extension-blur-my-shell
 dnf -y install \
 	xdg-desktop-portal \
 	xdg-desktop-portal-gnome
-	 
+
 # This is required so homebrew works indefinitely.
 # Symlinking it makes it so whenever another GCC version gets released it will break if the user has updated it without-
 # the homebrew package getting updated through our builds.

--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -3,11 +3,6 @@
 set -xeuo pipefail
 
 
-# This should only be enabled on `-dx`
-sed -i "/^show-boxbuddy=.*/d" /etc/dconf/db/distro.d/04-bluefin-logomenu-extension
-sed -i "/^show-boxbuddy=.*/d" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
-sed -i "/.*io.github.dvlv.boxbuddyrs.*/d" /etc/ublue-os/system-flatpaks.list
-
 # Offline Bluefin documentation
 curl --retry 3 -Lo /tmp/bluefin.pdf https://github.com/ublue-os/bluefin-docs/releases/download/0.1/bluefin.pdf
 install -Dm0644 -t /usr/share/doc/bluefin/ /tmp/bluefin.pdf

--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -2,17 +2,6 @@
 
 set -xeuo pipefail
 
-# Fancy CentOS icon on the fastfetch
-sed -i "s/󰣛//g" /usr/share/ublue-os/fastfetch.jsonc
-
-# Fix 1969 date getting returned on Fastfetch (upstream issue)
-# FIXME: check if this issue is fixed upstream at some point. (28-02-2025) https://github.com/ostreedev/ostree/issues/1469
-sed -i -e "s@ls -alct /@&var/log@g" /usr/share/ublue-os/fastfetch.jsonc
-
-# Automatic wallpaper changing by month
-HARDCODED_RPM_MONTH="12"
-sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/$(date +%m)/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
-glib-compile-schemas /usr/share/glib-2.0/schemas
 
 # This should only be enabled on `-dx`
 sed -i "/^show-boxbuddy=.*/d" /etc/dconf/db/distro.d/04-bluefin-logomenu-extension

--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -14,11 +14,6 @@ HARDCODED_RPM_MONTH="12"
 sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/$(date +%m)/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
 glib-compile-schemas /usr/share/glib-2.0/schemas
 
-# Required for bluefin faces to work without conflicting with a ton of packages
-rm -f /usr/share/pixmaps/faces/* || echo "Expected directory deletion to fail"
-mv /usr/share/pixmaps/faces/bluefin/* /usr/share/pixmaps/faces
-rm -rf /usr/share/pixmaps/faces/bluefin
-
 # This should only be enabled on `-dx`
 sed -i "/^show-boxbuddy=.*/d" /etc/dconf/db/distro.d/04-bluefin-logomenu-extension
 sed -i "/^show-boxbuddy=.*/d" /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override

--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -18,12 +18,12 @@ cat >$IMAGE_INFO <<EOF
 EOF
 
 OLD_PRETTY_NAME="$(sh -c '. /usr/lib/os-release ; echo $NAME $VERSION')"
-IMAGE_PRETTY_NAME="Bluefin LTS"
+IMAGE_PRETTY_NAME="Bluekitten"
 HOME_URL="https://projectbluefin.io"
 DOCUMENTATION_URL="https://docs.projectbluefin.io"
 SUPPORT_URL="https://github.com/ublue-os/bluefin-lts/issues/"
 BUG_SUPPORT_URL="https://github.com/ublue-os/bluefin-lts/issues/"
-CODE_NAME="Achillobator Giganticus"
+CODE_NAME="Achillobator"
 
 # OS Release File (changed in order with upstream)
 sed -i -f - /usr/lib/os-release <<EOF
@@ -33,7 +33,7 @@ s/^VARIANT_ID=.*/VARIANT_ID=${IMAGE_NAME}/
 s/^PRETTY_NAME=.*/PRETTY_NAME=\"${IMAGE_PRETTY_NAME}\"/
 s|^HOME_URL=.*|HOME_URL=\"${HOME_URL}\"|
 s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"${BUG_SUPPORT_URL}\"|
-s|^CPE_NAME=\"cpe:/o:centos:centos|CPE_NAME=\"cpe:/o:universal-blue:bluefin-lts|
+s|^CPE_NAME=\"cpe:/o:centos:centos|CPE_NAME=\"cpe:/o:jamesreilly:bluekitten-lts|
 
 /^REDHAT_BUGZILLA_PRODUCT=/d
 /^REDHAT_BUGZILLA_PRODUCT_VERSION=/d
@@ -44,6 +44,6 @@ EOF
 tee -a /usr/lib/os-release <<EOF
 DOCUMENTATION_URL="${DOCUMENTATION_URL}"
 SUPPORT_URL="${SUPPORT_URL}"
-DEFAULT_HOSTNAME="bluefin"
+DEFAULT_HOSTNAME="bluekitten"
 BUILD_ID="${SHA_HEAD_SHORT:-testing}"
 EOF

--- a/system_files/usr/share/ublue-os/motd/template.md
+++ b/system_files/usr/share/ublue-os/motd/template.md
@@ -1,4 +1,4 @@
-# 󱍢 Welcome to Bluefin LTS
+# 󱍢 Welcome to Bluekitten LTS
 
 󱋩 `%IMAGE_NAME%:%IMAGE_TAG%`
 


### PR DESCRIPTION
Eliminate references to Bluefin and update the branding to Bluekitten throughout the project.